### PR TITLE
Adding KITTI utility functions for computing transformation matrices and adding visualization for overlaying lidar on images.

### DIFF
--- a/kitti_utils.py
+++ b/kitti_utils.py
@@ -1,20 +1,23 @@
 from __future__ import absolute_import, division, print_function
-
 import os
 import numpy as np
 
-def load_velodyne_points(filename):
+def load_lidar_points(filename):
     """
-    Load 3D point cloud from KITTI file format.
+    This function loads 3D point cloud from KITTI file format.
+    :param [string] filename: File path for 3d point cloud data.
+    :return [np.array]: [N, 3] N lidar points represented as (X, Y, Z) points.
     """
     lidar_point_coord_velodyne = np.fromfile(filename, dtype=np.float32).reshape(-1, 4)
-    #Delete bottom row of reflectance value so columns are just [X, Y, Z]
-    lidar_point_coord_velodyne = lidar_point_coord_velodyne[:, :3]
-    return lidar_point_coord_velodyne
+    # Delete bottom row of reflectance value so columns are just [X, Y, Z]
+    return lidar_point_coord_velodyne[:, :3]
 
-def read_calib_file(path):
-    """Read KITTI calibration file
+def read_calibration_file(path):
+    """
+    This function reads the KITTI calibration file.
     (from https://github.com/hunse/kitti)
+    :param [string] path: File path for KITTI calbration file.
+    :return [dictionary] data: Dictionary containing the camera intrinsic and extrinsic matrices.
     """
     float_chars = set("0123456789.e+- ")
     data = {}
@@ -24,39 +27,40 @@ def read_calib_file(path):
             value = value.strip()
             data[key] = value
             if float_chars.issuperset(value):
-                # try to cast to float array
+                # Try to cast to float array.
                 try:
                     data[key] = np.array(list(map(float, value.split(' '))))
                 except ValueError:
-                    # casting error: data[key] already eq. value, so pass
+                    # Casting error: data[key] already eq. value, so pass.
                     pass
 
     return data
 
-def compute_image_from_velodyne_matrices(calib_dir):
+def compute_image_from_velodyne_matrices(calibration_dir):
     """
     This function computes the transformation matrix to project 3D lidar points into the 2D image plane.
-    :param [String] calib_dir: Directory to folder containing camera/velodyne calibration files
-    :return:  dictionary of numpy.arrays of shape [4,4] that converts 3D lidar pts to 2D image plane for each camera
-    (keys: cam0, cam1, cam2, cam3)
+    :param [String] calibration_dir: Directory to folder containing camera/lidar calibration files
+    :return:  dictionary of numpy.arrays of shape [4, 4] that converts 3D lidar points to 2D image plane for each camera
+    (keys: cam00, cam01, cam02, cam03)
     """
-    #Based on code from monodepth2 repo.
+    # Based on code from monodepth2 repo.
     
-    #Load cam_to_cam calib file.
-    cam2cam = read_calib_file(os.path.join(calib_dir, 'calib_cam_to_cam.txt'))
-    #Load velo_to_cam file.
-    velo2cam = read_calib_file(os.path.join(calib_dir, 'calib_velo_to_cam.txt'))
+    # Load cam_to_cam calib file.
+    cam2cam = read_calibration_file(os.path.join(calibration_dir, 'calib_cam_to_cam.txt'))
+    # Load velo_to_cam file.
+    velo2cam = read_calibration_file(os.path.join(calibration_dir, 'calib_velo_to_cam.txt'))
 
-    velo2cam = np.hstack((velo2cam['R'].reshape(3, 3), velo2cam['T'].reshape(3,1)))#Adds T vals in 4th column.
+    velo2cam = np.hstack((velo2cam['R'].reshape(3, 3), velo2cam['T'].reshape(3, 1)))
     velo2cam = np.vstack((velo2cam, np.array([0, 0, 0, 1.0])))
     camera_image_from_velodyne_dict = {}
 
-    for cam in range(4):
+    KITTI_CAMERA_NAMES = ['00', '01', '02', '03']
+    for camera_name in KITTI_CAMERA_NAMES:
         R_cam2rect = np.eye(4)
-        R_cam2rect[:3, :3] = cam2cam['R_rect_0' + str(cam)].reshape(3,3)#Fills top left 3x3 with R vals.
-        P_rect = cam2cam['P_rect_0' + str(cam)].reshape(3,4)
+        R_cam2rect[:3, :3] = cam2cam[f"R_rect_{camera_name}"].reshape(3, 3) 
+        P_rect = cam2cam[f"P_rect_{camera_name}"].reshape(3, 4)
         camera_image_from_velodyne = np.dot(np.dot(P_rect, R_cam2rect), velo2cam)
         camera_image_from_velodyne = np.vstack((camera_image_from_velodyne, np.array([[0, 0, 0, 1.0]])))
-        camera_image_from_velodyne_dict.update({'cam'+str(cam) : camera_image_from_velodyne})
+        camera_image_from_velodyne_dict.update({f"cam{camera_name}" : camera_image_from_velodyne})
     
     return camera_image_from_velodyne_dict

--- a/kitti_utils_test.py
+++ b/kitti_utils_test.py
@@ -1,43 +1,43 @@
 import kitti_utils as ku
-import os
-import unittest
+import pytest
+import math
 import numpy as np
+import os
 
-class TestKittiUtils(unittest.TestCase):
-    def test_load_velodyne_points(self):
-        """
-        Tests the return of the load_velodyne_points funtion in kitti_utils.py
-        """
-        lidar_point_coord_velodyne = ku.load_velodyne_points('data/kitti_example/2011_09_26/2011_09_26_drive_0048_sync/velodyne_points/data/0000000010.bin')
-        self.assertEqual(lidar_point_coord_velodyne.shape, (116006, 3))
-        self.assertAlmostEqual(lidar_point_coord_velodyne[0][0], 73.89, 4)
-        self.assertAlmostEqual(lidar_point_coord_velodyne[0][1], 7.028, 4)
+def test_load_lidar_points():
+    """
+    Tests the return of the load_velodyne_points funtion in kitti_utils.py
+    """
+    SAMPLE_LIDAR_POINTS_PATH = 'data/kitti_example/2011_09_26/2011_09_26_drive_0048_sync/velodyne_points/data/0000000010.bin'
+    lidar_point_coord_velodyne = ku.load_lidar_points(SAMPLE_LIDAR_POINTS_PATH)
+    assert lidar_point_coord_velodyne.shape == (116006, 3)
+    assert math.isclose(lidar_point_coord_velodyne[0][0], 73.89, rel_tol = .00001)
+    assert math.isclose(lidar_point_coord_velodyne[0][1], 7.028, rel_tol = .00001)
         
+def test_read_calibration_file():
+    """
+    Tests the return of the read_calibration_file funtion in kitti_utils.py
+    """
+    CALIBRATION_DIR = 'data/kitti_example/2011_09_26'
+    cam2cam = ku.read_calibration_file(os.path.join(CALIBRATION_DIR, 'calib_cam_to_cam.txt'))
+    velo2cam = ku.read_calibration_file(os.path.join(CALIBRATION_DIR, 'calib_velo_to_cam.txt'))
+    imu2cam = ku.read_calibration_file(os.path.join(CALIBRATION_DIR, 'calib_imu_to_velo.txt'))
+    assert len(cam2cam) == 34
+    assert len(velo2cam) == 5
+    assert len(imu2cam) == 3
 
-    def test_read_calib_file(self):
-        """
-        Tests the return of the read_calib_file funtion in kitti_utils.py
-        """
-        calib_dir = 'data/kitti_example/2011_09_26'
-        cam2cam = ku.read_calib_file(os.path.join(calib_dir, 'calib_cam_to_cam.txt'))
-        velo2cam = ku.read_calib_file(os.path.join(calib_dir, 'calib_velo_to_cam.txt'))
-        imu2cam = ku.read_calib_file(os.path.join(calib_dir, 'calib_imu_to_velo.txt'))
-        self.assertEqual(len(cam2cam), 34)
-        self.assertEqual(len(velo2cam), 5)
-        self.assertEqual(len(imu2cam), 3)
-
-    def test_compute_image_from_velodyne_matrices(self):
-        """
-        Tests the return of the compute_image_from_velodyne_matrices funtion in kitti_utils.py
-        """
-        calib_dir = 'data/kitti_example/2011_09_26'
-        camera_image_from_velodyne_dict = ku.compute_image_from_velodyne_matrices(calib_dir)
-        self.assertEqual(len(camera_image_from_velodyne_dict), 4)
-        camera_image_from_velodyne = camera_image_from_velodyne_dict.get('cam0')
-        #check shape
-        testarr = np.array([[609.695409, -721.421597, -1.25125855, -167.899086],\
-                            [180.384202,  7.64479802, -719.651474, -101.233067],\
-                            [.999945389,  .000124365378,  .0104513030, -.272132796],\
-                            [0., 0., 0., 1.]])
-        self.assertTrue(np.allclose(camera_image_from_velodyne, testarr))
+def test_compute_image_from_velodyne_matrices():
+    """
+    Tests the return of the compute_image_from_velodyne_matrices funtion in kitti_utils.py
+    """
+    CALIBRATION_DIR = 'data/kitti_example/2011_09_26'
+    camera_image_from_velodyne_dict = ku.compute_image_from_velodyne_matrices(CALIBRATION_DIR)
+    assert len(camera_image_from_velodyne_dict) == 4
+    camera_image_from_velodyne = camera_image_from_velodyne_dict.get('cam00')
+    # Check shape.
+    testarr = np.array([[609.695409, -721.421597, -1.25125855, -167.899086], \
+                        [180.384202,  7.64479802, -719.651474, -101.233067], \
+                        [.999945389,  .000124365378,  .0104513030, -.272132796], \
+                        [0., 0., 0., 1.]])
+    assert np.allclose(camera_image_from_velodyne, testarr)
         

--- a/overlay_lidar_utils.py
+++ b/overlay_lidar_utils.py
@@ -1,73 +1,73 @@
 import numpy as np
 from collections import Counter
 from matplotlib import pyplot as plt
-import matplotlib.patches as patches
 import colorsys
 import kitti_utils
 
 def generate_lidar_point_coord_camera_image(lidar_point_coord_velodyne, camera_image_from_velodyne, im_width, im_height):
     """
-    This function removes the lidar pts that are not in the image plane, rounds x/y pixel vals for lidar pts, and projects the lidar pts onto the image plane
-    :param [numpy.array] lidar_point_coord_velodyne: [N,3], matrix of lidar pts, each row is format [X, Y, Z]
-    :param [numpy.array] camera_image_from_velodyne: [4,4], converts 3D lidar pts to 2D image plane
+    This function removes the lidar pointts that are not in the image plane, rounds x/y pixel values for lidar points, 
+    and projects the lidar points onto the image plane
+    :param [numpy.array] lidar_point_coord_velodyne: [N, 3], matrix of lidar points, each row is format [X, Y, Z]
+    :param [numpy.array] camera_image_from_velodyne: [4, 4], converts 3D lidar points to 2D image plane
     :param [int] im_width: width of image in pixels
     :param [int] im_height: height of image in pixels
-    :return: numpy.array of shape [N,4], contains lidar pts on image plane, each row is format [X, Y, depth, 1]
+    :return: numpy.array of shape [N, 4], contains lidar points on image plane, each row is format [X, Y, depth, 1]
     """
-    #Based on code from monodepth2 repo.
+    # Based on code from monodepth2 repo.
 
-    #Add bottom row of ones to lidar_point_coord_velodyne
-    lidar_point_coord_velodyne = np.hstack((lidar_point_coord_velodyne, np.ones((np.size(lidar_point_coord_velodyne,0)))[:, None]))
+    # Add right column of ones to lidar_point_coord_velodyne.
+    lidar_point_coord_velodyne = np.hstack((lidar_point_coord_velodyne, np.ones((np.size(lidar_point_coord_velodyne, 0)))[:, None]))
     
-    #Remove points behind camera.
-    lidar_point_coord_velodyne = lidar_point_coord_velodyne[lidar_point_coord_velodyne[:,0] >=0, :]
+    # Remove points behind velodyne sensor.
+    lidar_point_coord_velodyne = lidar_point_coord_velodyne[lidar_point_coord_velodyne[:, 0] >=0, :]
     
-    #Project points to image plane.
+    # Project points to image plane.
     lidar_point_coord_camera_image = np.dot(camera_image_from_velodyne, lidar_point_coord_velodyne.T).T
     lidar_point_coord_camera_image[:, :2] = lidar_point_coord_camera_image[:, :2] / lidar_point_coord_camera_image[:, 2][..., np.newaxis]
-  
-    #Check if in image FOV.
-    lidar_point_coord_camera_image[:, 0] = lidar_point_coord_camera_image[:, 0].astype(int) - 1
-    lidar_point_coord_camera_image[:, 1] = lidar_point_coord_camera_image[:, 1].astype(int) - 1
-    val_inds = (lidar_point_coord_camera_image[:, 0] >= 0) & (lidar_point_coord_camera_image[:, 1] >= 0)
-    val_inds = val_inds & (lidar_point_coord_camera_image[:, 0] < im_width) & (lidar_point_coord_camera_image[:, 1] < im_height)
-    lidar_point_coord_camera_image = lidar_point_coord_camera_image[val_inds, :]
     
-    return lidar_point_coord_camera_image
+    # Round X and Y pixel coordinates to int.
+    lidar_point_coord_camera_image = np.around(lidar_point_coord_camera_image).astype(int)
 
-def render_lidar_on_image(image, lidar_point_coord_camera_image):
+    # Filtering points to only inlude those in image field of view.
+    filtered_index = (lidar_point_coord_camera_image[:, 0] >= 0) & (lidar_point_coord_camera_image[:, 1] >= 0) & \
+                    (lidar_point_coord_camera_image[:, 0] < im_width) & (lidar_point_coord_camera_image[:, 1] < im_height)
+    
+    return lidar_point_coord_camera_image[filtered_index, :]
+
+def plot_lidar_on_image(image, lidar_point_coord_camera_image):
     """
     This function plots lidar points on the image with colors corresponding to their depth(higher hsv hue val = further away) 
     :param [numpy.array] image: [H, W], contains image data
-    :param [numpy.array] lidar_point_coord_camera_image: [N,4], contains lidar pts on image plane, each row is format [X, Y, depth, 1]
-    :return: no return val, shows image w/ lidar overlay
+    :param [numpy.array] lidar_point_coord_camera_image: [N, 4], contains lidar points on image plane, each row is format [X, Y, depth, 1]
+    :return: None. Plots image w/ lidar overlay.
     """
-    #Normalize depth values.
-    lidar_point_depth = lidar_point_coord_camera_image[:, 2].reshape(-1,1)
-    lidar_point_depth_normalized = normalize_depth(lidar_point_depth)
-   
-    #Show grayscale image.
-    plt.figure(figsize=(20, 20))
-    ax = plt.gca()
+    # Normalize depth values.
+    lidar_point_coord_camera_image = normalize_depth(lidar_point_coord_camera_image[:, :3])
+    
+    # Make array of colors (row number is equal to row number containing corresponding x/y point in lidar_point_coord_camera_image)
+    colors = np.zeros(lidar_point_coord_camera_image.shape)
+    for idx in range(len(colors)):
+        #col = np.asarray(colorsys.hsv_to_rgb(lidar_point_coord_camera_image[idx][2] * (240/360), 1.0, 1.0))
+        #colors[idx] = np.array([[col[0], col[1], col[2]]])
+        colors[idx] = np.asarray(colorsys.hsv_to_rgb(lidar_point_coord_camera_image[idx][2] * (240/360), 1.0, 1.0))
+    
+    # Show grayscale image.
     plt.imshow(image, cmap='Greys_r')
     
-    #Plot lidar points.
-    for idx in range(len(lidar_point_coord_camera_image)):
-        normalized_depth = np.asscalar(lidar_point_depth_normalized[idx][0])
-        col = colorsys.hsv_to_rgb(normalized_depth * (240/360), 1.0, 1.0)
-        circ = patches.Circle((lidar_point_coord_camera_image[idx][0],lidar_point_coord_camera_image[idx][1]),2)
-        circ.set_facecolor(col) 
-        ax.add_patch(circ)
-    
+    # Plot lidar points.
+    plt.scatter(lidar_point_coord_camera_image[:, 0], lidar_point_coord_camera_image[:, 1], c = colors, s = 5)
     plt.show()
 
-def normalize_depth(lidar_point_depth):
+def normalize_depth(lidar_point_coord_camera_image):
     """
-    This function normalizes the depth values that are passed so they are between 0 and 1, inclusive 
-    :param [numpy.array] lidar_point_depth: [N, 1] contains all of the depth values for points that are in the image FOV
-    :return: numpy.array of shape [N,1] containing the depth values normalized so they are between 0 and 1, inclusive
+    This function normalizes the depth values in lidar_point_coord_camera_image so they are between 0 and 1, inclusive 
+    :param [numpy.array] lidar_point_coord_camera_image: [N, 3] contains lidar points on image plane, each row is format [X, Y, depth]
+    :return: numpy.array of shape [N, 3] containing the normalized lidar points on image plane, each row is format [X, Y, normalized depth] 
+            (normalized depth is between 0 and 1, inclusive)
     """
-    max = lidar_point_depth.max()
-    min = lidar_point_depth.min()
-    lidar_point_depth_normalized = (lidar_point_depth - min)/(max-min)
-    return lidar_point_depth_normalized
+    lidar_point_coord_camera_image = lidar_point_coord_camera_image.astype('float32')
+    max = lidar_point_coord_camera_image[:, 2].max()
+    min = lidar_point_coord_camera_image[:, 2].min()
+    lidar_point_coord_camera_image[:, 2] = (lidar_point_coord_camera_image[:, 2] - min)/(max-min)
+    return lidar_point_coord_camera_image

--- a/overlay_lidar_utils_test.py
+++ b/overlay_lidar_utils_test.py
@@ -1,21 +1,20 @@
-import unittest
+import pytest
 import overlay_lidar_utils as olu
 import numpy as np
 
-class TestOverlayLidarUitls(unittest.TestCase):
-    def test_generate_lidar_point_coord_camera_image(self):
-        """
-        Tests the return of the generate_lidar_point_coord_camera_image_test function in overlay_lidar_utils.py
-        """
-        lidar_point_coord_velodyne = np.array([[10, 10, 10], [10, 10, 10]])
-        camera_image_from_velodyne = np.eye(4)
-        lidar_point_coord_camera_image = olu.generate_lidar_point_coord_camera_image(lidar_point_coord_velodyne, camera_image_from_velodyne, 100, 100)
-        self.assertTrue(np.array_equal(lidar_point_coord_camera_image, np.array([[0., 0., 10., 1.], [0., 0., 10., 1.]])))
+def test_generate_lidar_point_coord_camera_image():
+    """
+    Tests the return of the generate_lidar_point_coord_camera_image_test function in overlay_lidar_utils.py
+    """
+    lidar_point_coord_velodyne = np.array([[10, 10, 10], [10, 10, 10]])
+    camera_image_from_velodyne = np.eye(4)
+    lidar_point_coord_camera_image = olu.generate_lidar_point_coord_camera_image(lidar_point_coord_velodyne, camera_image_from_velodyne, 100, 100)
+    assert np.array_equal(lidar_point_coord_camera_image, np.array([[1., 1., 10., 1.], [1., 1., 10., 1.]]))
 
-    def test_normalize_depth(self):
-        """
-        Tests the return of the normalize_depth function in overlay_lidar_utils.py
-        """
-        lidar_point_depth = np.array([[-1], [5], [9]])
-        norm_depth = olu.normalize_depth(lidar_point_depth)
-        self.assertTrue(np.array_equal(norm_depth, np.array([[0.], [0.6], [1.]])))
+def test_normalize_depth():
+    """
+    Tests the return of the normalize_depth function in overlay_lidar_utils.py
+    """
+    lidar_point_depth = np.array([[0, 0, -1], [0, 0, 5], [0, 0, 9]])
+    norm_depth = olu.normalize_depth(lidar_point_depth)[:, 2]
+    assert np.array_equal(norm_depth, np.array([0., 0.6, 1.]).astype('float32'))


### PR DESCRIPTION
Includes functions necessary to project 3D lidar points onto the 2D image plane and create a visualization that overlays a color-coded depth map onto an image. Functions specific to KITTI are in `kitti_utils.py` and functions that could be used with other datasets are in `overlay_lidar_utils.py`.

Code to produce sample visualization:

```
import matplotlib.image as mpimg
import kitti_utils as ku
import overlay_lidar_utils as olu
import os
from matplotlib import pyplot as plt

# Load lidar points.
lidar_point_coord_velodyne = ku.load_lidar_points('data/kitti_example/2011_09_26/2011_09_26_drive_0048_sync/velodyne_points/data/0000000010.bin')
# Load image file.
image = mpimg.imread('data/kitti_example/2011_09_26/2011_09_26_drive_0048_sync/image_00/data/0000000010.png')
# Overlay lidar points.
calib_dir = '/Users/aaronmarmolejos/Documents/workspace/DDSR2020/data/kitti_example/2011_09_26'
camera_image_from_velodyne = ku.compute_image_from_velodyne_matrices(calib_dir).get('cam00')
lidar_point_coord_camera_image = olu.generate_lidar_point_coord_camera_image(lidar_point_coord_velodyne, camera_image_from_velodyne, 1242, 375)

plt.figure(figsize=(20, 20))
olu.plot_lidar_on_image(image, lidar_point_coord_camera_image)
```

Sample visualization:
![image](https://user-images.githubusercontent.com/66326102/84449594-db350180-ac1b-11ea-89fa-80e4bd84b6e6.png)

Sample Tests:

kitti_utils.py:
```
$ pytest kitti_utils_test.py
============================= test session starts ==============================
platform darwin -- Python 3.7.6, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: /Users/aaronmarmolejos/Documents/workspace/DDSR2020
plugins: hypothesis-5.5.4, arraydiff-0.3, remotedata-0.3.2, openfiles-0.4.0, doctestplus-0.5.0, astropy-header-0.1.2
collected 3 items                                                              

kitti_utils_test.py ...                                                  [100%]

============================== 3 passed in 0.09s ===============================
```

overlay_lidar_utils.py:

```
$ pytest overlay_lidar_utils_test.py
============================= test session starts ==============================
platform darwin -- Python 3.7.6, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: /Users/aaronmarmolejos/Documents/workspace/DDSR2020
plugins: hypothesis-5.5.4, arraydiff-0.3, remotedata-0.3.2, openfiles-0.4.0, doctestplus-0.5.0, astropy-header-0.1.2
collected 2 items                                                              

overlay_lidar_utils_test.py ..                                           [100%]

============================== 2 passed in 0.98s ===============================
```
