### PR TITLE
Fixed occasional NaN's coming out of binned metrics

### DIFF
--- a/ddsr/monodepth_metrics.py
+++ b/ddsr/monodepth_metrics.py
@@ -169,7 +169,7 @@ def run_metrics(log_dir, epoch):
     med = np.median(ratios)
     print(" Scaling ratios | med: {:0.3f} | std: {:0.3f}".format(med, np.std(ratios / med)))
 
-    mean_errors = errors.mean(0)
+    mean_errors = np.nanmean(errors, 0)
 
     print("\n  " + ("{:>11} | " * len(labels)).format(*labels))
     print(("&{: 11.3f}  " * len(labels)).format(*mean_errors.tolist()) + "\\\\")


### PR DESCRIPTION
Accommodated for occasional wacky gt-depth with maximum depth values of 10, preventing nans from appearing in bins.